### PR TITLE
Modifications needed to allow to print a JFreeChart into a PDF document

### DIFF
--- a/src/main/java/de/rototor/pdfbox/graphics2d/PdfBoxGraphics2D.java
+++ b/src/main/java/de/rototor/pdfbox/graphics2d/PdfBoxGraphics2D.java
@@ -241,7 +241,7 @@ public class PdfBoxGraphics2D extends Graphics2D {
 			contentStream.saveGraphicsState();
 
 			// Possibly set the alpha constant
-			if((composite != null) && (composite instanceof AlphaComposite))
+			if(composite instanceof AlphaComposite)
 			{
 				float alpha = ((AlphaComposite)composite).getAlpha();
 				if(alpha < 1)
@@ -497,7 +497,7 @@ public class PdfBoxGraphics2D extends Graphics2D {
 			contentStream.saveGraphicsState();
 
 			// Possibly set the alpha constant
-			if((composite != null) && (composite instanceof AlphaComposite))
+			if(composite instanceof AlphaComposite)
 			{
 				float alpha = ((AlphaComposite)composite).getAlpha();
 				if(alpha < 1)


### PR DESCRIPTION
I tried to use your classes to print a JFreeChart into a PDF document (see code example below):

```
PDDocument document = ...;
PDPageContentStream contentStream = ...;

JFreeChart chart = ...;

float posX  = ...; float posY   = ...;
int   width = ...; int   height = ...;

PdfBoxGraphics2D pdfBoxGraphics2D = new PdfBoxGraphics2D(document, width, height);
Rectangle2D rectangle = new Rectangle2D.Double(0, 0, width, height);
chart.draw(pdfBoxGraphics2D, rectangle);

pdfBoxGraphics2D.dispose();

PDFormXObject xform = pdfBoxGraphics2D.getXFormObject();

Matrix matrix = new Matrix();
matrix.translate(posX, posY);
contentStream.transform(matrix);
contentStream.drawForm(xform);

pdfBoxGraphics2D.saveGraphicsState(); // See my modifications in class

...
```

It works fine, but as JFreeChart uses objects a person wouldn't consciously use (for instance rectangles with zero width), I had to do some code modifications (only in class PdfBoxGraphics2D).
I also added the support for the alpha value.
 
Please, find the file attached: you can locate my changes by looking for string "TODO MODIFICATION" (a comment explains each change).
It would be great if you could make a new version of pdfbox-graphics2d, incorporating my code.