### PR TITLE
Workaround to avoid calls to contentStream.moveTo with NaN arguments.

### DIFF
--- a/src/main/java/de/rototor/pdfbox/graphics2d/PdfBoxGraphics2D.java
+++ b/src/main/java/de/rototor/pdfbox/graphics2d/PdfBoxGraphics2D.java
@@ -829,24 +829,27 @@ public class PdfBoxGraphics2D extends Graphics2D {
 		PathIterator pi = clip.getPathIterator(tf);
 		float[] coords = new float[6];
 		while (!pi.isDone()) {
-			switch (pi.currentSegment(coords)) {
-			case PathIterator.SEG_MOVETO:
-				contentStream.moveTo(coords[0], coords[1]);
-				break;
-			case PathIterator.SEG_LINETO:
-				contentStream.lineTo(coords[0], coords[1]);
-				break;
-			case PathIterator.SEG_QUADTO:
-				contentStream.curveTo1(coords[0], coords[1], coords[2], coords[3]);
-				break;
-			case PathIterator.SEG_CUBICTO:
-				contentStream.curveTo(coords[0], coords[1], coords[2], coords[3], coords[4], coords[5]);
-				break;
-			case PathIterator.SEG_CLOSE:
-				contentStream.closePath();
-				break;
+			int segment = pi.currentSegment(coords);
+			if(Float.isFinite(coords[0])) {
+				switch (segment) {
+				case PathIterator.SEG_MOVETO:
+					contentStream.moveTo(coords[0], coords[1]);
+					break;
+				case PathIterator.SEG_LINETO:
+					contentStream.lineTo(coords[0], coords[1]);
+					break;
+				case PathIterator.SEG_QUADTO:
+					contentStream.curveTo1(coords[0], coords[1], coords[2], coords[3]);
+					break;
+				case PathIterator.SEG_CUBICTO:
+					contentStream.curveTo(coords[0], coords[1], coords[2], coords[3], coords[4], coords[5]);
+					break;
+				case PathIterator.SEG_CLOSE:
+					contentStream.closePath();
+					break;
+				}
+				pi.next();
 			}
-			pi.next();
 		}
 	}
 

--- a/src/main/java/de/rototor/pdfbox/graphics2d/PdfBoxGraphics2D.java
+++ b/src/main/java/de/rototor/pdfbox/graphics2d/PdfBoxGraphics2D.java
@@ -848,8 +848,8 @@ public class PdfBoxGraphics2D extends Graphics2D {
 					contentStream.closePath();
 					break;
 				}
-				pi.next();
 			}
+			pi.next();
 		}
 	}
 


### PR DESCRIPTION
I’ve found a little bug in Graphics2d (always present since version 0.1).
I use this bridge to put JFreeChart into PDF.
I happened to have a JFreeChart spider chart with no data; in that case, in method walkShape (class PdfBoxGraphics2D) there are calls to contentStream.moveTo(NaN, NaN).

I propose a workaround for this issue: it works, but maybe there's a better solution