### PR TITLE
add font width test case

### DIFF
--- a/src/test/java/de/rototor/pdfbox/graphics2d/FontWidthDiscrepancyTest.java
+++ b/src/test/java/de/rototor/pdfbox/graphics2d/FontWidthDiscrepancyTest.java
@@ -1,0 +1,41 @@
+package de.rototor.pdfbox.graphics2d;
+
+import org.junit.Test;
+
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.font.PDFont;
+import org.apache.pdfbox.pdmodel.font.PDType0Font;
+
+import java.awt.*;
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class FontWidthDiscrepancyTest extends PdfBoxGraphics2DTestBase {
+        @Test
+        public void testAnonioFontWidth() throws IOException, FontFormatException
+        {
+                final PDDocument doc = new PDDocument();
+                final String testString = "MMMMMMMMMMMMMMMMMMMMMM";
+                final float fontSize = 20f;
+                final Font antonioRegular = Font
+                        .createFont(Font.TRUETYPE_FONT,
+                                        PdfBoxGraphics2dTest.class.getResourceAsStream("antonio/Antonio-Regular.ttf"))
+                        .deriveFont(fontSize);
+                final PDFont pdFont =  PDType0Font
+                        .load(doc, PdfBoxGraphics2dTest.class.getResourceAsStream("antonio/Antonio-Regular.ttf"));
+
+                final Graphics2D gfx = new PdfBoxGraphics2D(doc, 400, 400);
+
+                float pdfWidth = pdFont.getStringWidth(testString) / 1000 * fontSize;
+                float gfxWidth = gfx.getFontMetrics(antonioRegular).stringWidth(testString);
+                
+                gfx.dispose();
+
+                assertEquals(pdfWidth, gfxWidth, 1.0);
+               
+        }
+
+}


### PR DESCRIPTION
This test shows the discrepancy between measuring a font using `graphics2D.getFontMetrics.stringWidth` and `pdFont.getStringWidth`.

I decided to use only 'M's for the test case as this exacerbates the problem using the Antonio-font. Using the english alphabet shows a much smaller discrepancy, but all measurements are dependent on font, font size and letters contained in the test string.
