### PR TITLE
Fix stroke width in for lines in rotated transform spaces

### DIFF
--- a/graphics2d/src/main/java/de/rototor/pdfbox/graphics2d/PdfBoxGraphics2D.java
+++ b/graphics2d/src/main/java/de/rototor/pdfbox/graphics2d/PdfBoxGraphics2D.java
@@ -558,7 +558,7 @@ public class PdfBoxGraphics2D extends Graphics2D
         // Apply the current transform to the horizontal line.
         tf.deltaTransform(lengthVector, lengthVector);
         // Calculate the length of the transformed line. This is the new, adjusted length.
-        return (float)(Math.sqrt(lengthVector.x * lengthVector.x + lengthVector.y * lengthVector.y));
+        return (float) Math.sqrt(lengthVector.x * lengthVector.x + lengthVector.y * lengthVector.y);
     }
 
     private AffineTransform getCurrentEffectiveTransform()

--- a/graphics2d/src/main/java/de/rototor/pdfbox/graphics2d/PdfBoxGraphics2D.java
+++ b/graphics2d/src/main/java/de/rototor/pdfbox/graphics2d/PdfBoxGraphics2D.java
@@ -49,6 +49,7 @@ import java.awt.geom.Ellipse2D;
 import java.awt.geom.Line2D;
 import java.awt.geom.NoninvertibleTransformException;
 import java.awt.geom.Path2D;
+import java.awt.geom.Point2D;
 import java.awt.geom.PathIterator;
 import java.awt.geom.Rectangle2D;
 import java.awt.geom.RoundRectangle2D;
@@ -287,7 +288,7 @@ public class PdfBoxGraphics2D extends Graphics2D
 
 	/**
 	 * *AFTER* you have disposed() this Graphics2D you can access the XForm
-	 * 
+	 *
 	 * @return the PDFormXObject which resulted in this graphics
 	 */
     @SuppressWarnings("WeakerAccess")
@@ -532,8 +533,18 @@ public class PdfBoxGraphics2D extends Graphics2D
             AffineTransform tf = getCurrentEffectiveTransform();
 
             double scaleX = tf.getScaleX();
-            contentStream.setLineWidth((float) Math.abs(basicStroke.getLineWidth() * scaleX));
+
+            // Represent stroke width as a vector.
+            Point2D.Float penSize = new Point2D.Float(0f, basicStroke.getLineWidth());
+            // Apply the current transform to the vector.
+            tf.deltaTransform(penSize, penSize);
+            // Calculate the magnitude of the vector.
+            float lineWidth = (float)(Math.sqrt(penSize.x * penSize.x + penSize.y * penSize.y));
+            contentStream.setLineWidth(lineWidth);
+
+
             float[] dashArray = basicStroke.getDashArray();
+
             if (dashArray != null)
             {
                 for (int i = 0; i < dashArray.length; i++)

--- a/graphics2d/src/test/java/de/rototor/pdfbox/graphics2d/RenderSVGsTest.java
+++ b/graphics2d/src/test/java/de/rototor/pdfbox/graphics2d/RenderSVGsTest.java
@@ -39,6 +39,13 @@ public class RenderSVGsTest extends PdfBoxGraphics2DTestBase
     }
 
     @Test
+    public void testRotatedStrokes() throws IOException
+    {
+        renderSVG("strokeRotation.svg", 0.55);
+        renderSVG("dashedStrokeRotation.svg", 0.55);
+    }
+
+    @Test
     public void renderFailureCases() throws IOException
     {
         // renderSVG("openhtml_536.svg", 1);

--- a/graphics2d/src/test/resources/de/rototor/pdfbox/graphics2d/dashedStrokeRotation.svg
+++ b/graphics2d/src/test/resources/de/rototor/pdfbox/graphics2d/dashedStrokeRotation.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="" width="613" height="380" viewBox="0 0 613 380">
+  <g data-z-index="3">
+    <g data-z-index="4" transform="translate(598,258) rotate(90) scale(-1,1) scale(1 1)">
+      <rect x="166.56666666667002" y="220" width="21" height="156" fill="#9bda44" stroke="#000000" stroke-width="10" stroke-dasharray="80,30,10,30,10,30"/>
+    </g>
+  </g>
+</svg>

--- a/graphics2d/src/test/resources/de/rototor/pdfbox/graphics2d/strokeRotation.svg
+++ b/graphics2d/src/test/resources/de/rototor/pdfbox/graphics2d/strokeRotation.svg
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.0//EN" "http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg" contentScriptType="text/ecmascript" width="613" zoomAndPan="magnify" style="" contentStyleType="text/css" viewBox="0 0 613 380" height="380" preserveAspectRatio="xMidYMid meet" version="1.1">
+  <g data-z-index="2">
+    <svg xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg" contentScriptType="text/ecmascript" zoomAndPan="magnify" contentStyleType="text/css" style="overflow: visible;" elementId="3" data-z-index="7" version="1.0" width="1" preserveAspectRatio="xMidYMid meet" viewBox="0 0 75 75" height="1">
+      <g transform="translate(15000,15000)">
+        <g>
+          <path stroke-width="500" d="M0 336 H12800" class="underline" stroke="#595959"/>
+        </g>
+        <g transform="rotate(15, 0, 0)">
+          <g>
+            <path stroke-width="500" d="M0 336 H12800" class="underline" stroke="#595959"/>
+          </g>
+        </g>
+        <g transform="rotate(30, 0, 0)">
+          <g>
+            <path stroke-width="500" d="M0 336 H12800" class="underline" stroke="#595959"/>
+          </g>
+        </g>
+        <g transform="rotate(45, 0, 0)">
+          <g>
+            <path stroke-width="500" d="M0 336 H12800" class="underline" stroke="#595959"/>
+          </g>
+        </g>
+        <g transform="rotate(60, 0, 0)">
+          <g>
+            <path stroke-width="500" d="M0 336 H12800" class="underline" stroke="#595959"/>
+          </g>
+        </g>
+        <g transform="rotate(75, 0, 0)">
+          <g>
+            <path stroke-width="500" d="M0 336 H12800" class="underline" stroke="#595959"/>
+          </g>
+        </g>
+        <g transform="rotate(90, 0, 0)">
+          <g>
+            <path stroke-width="500" d="M0 336 H12800" class="underline" stroke="#595959"/>
+          </g>
+        </g>
+        <g transform="rotate(105, 0, 0)">
+          <g>
+            <path stroke-width="500" d="M0 336 H12800" class="underline" stroke="#595959"/>
+          </g>
+        </g>
+        <g transform="rotate(120, 0, 0)">
+          <g>
+            <path stroke-width="500" d="M0 336 H12800" class="underline" stroke="#595959"/>
+          </g>
+        </g>
+        <g transform="rotate(135, 0, 0)">
+          <g>
+            <path stroke-width="500" d="M0 336 H12800" class="underline" stroke="#595959"/>
+          </g>
+        </g>
+        <g transform="rotate(150, 0, 0)">
+          <g>
+            <path stroke-width="500" d="M0 336 H12800" class="underline" stroke="#595959"/>
+          </g>
+        </g>
+        <g transform="rotate(165, 0, 0)">
+          <g>
+            <path stroke-width="500" d="M0 336 H12800" class="underline" stroke="#595959"/>
+          </g>
+        </g>
+        <g transform="rotate(180, 0, 0)">
+          <g>
+            <path stroke-width="500" d="M0 336 H12800" class="underline" stroke="#595959"/>
+          </g>
+        </g>
+        <g transform="rotate(195, 0, 0)">
+          <g>
+            <path stroke-width="500" d="M0 336 H12800" class="underline" stroke="#595959"/>
+          </g>
+        </g>
+        <g transform="rotate(210, 0, 0)">
+          <g>
+            <path stroke-width="500" d="M0 336 H12800" class="underline" stroke="#595959"/>
+          </g>
+        </g>
+        <g transform="rotate(225, 0, 0)">
+          <g>
+            <path stroke-width="500" d="M0 336 H12800" class="underline" stroke="#595959"/>
+          </g>
+        </g>
+        <g transform="rotate(240, 0, 0)">
+          <g>
+            <path stroke-width="500" d="M0 336 H12800" class="underline" stroke="#595959"/>
+          </g>
+        </g>
+        <g transform="rotate(255, 0, 0)">
+          <g>
+            <path stroke-width="500" d="M0 336 H12800" class="underline" stroke="#595959"/>
+          </g>
+        </g>
+        <g transform="rotate(270, 0, 0)">
+          <g>
+            <path stroke-width="500" d="M0 336 H12800" class="underline" stroke="#595959"/>
+          </g>
+        </g>
+        <g transform="rotate(285, 0, 0)">
+          <g>
+            <path stroke-width="500" d="M0 336 H12800" class="underline" stroke="#595959"/>
+          </g>
+        </g>
+        <g transform="rotate(300, 0, 0)">
+          <g>
+            <path stroke-width="500" d="M0 336 H12800" class="underline" stroke="#595959"/>
+          </g>
+        </g>
+        <g transform="rotate(315, 0, 0)">
+          <g>
+            <path stroke-width="500" d="M0 336 H12800" class="underline" stroke="#595959"/>
+          </g>
+        </g>
+        <g transform="rotate(330, 0, 0)">
+          <g>
+            <path stroke-width="500" d="M0 336 H12800" class="underline" stroke="#595959"/>
+          </g>
+        </g>
+        <g transform="rotate(345, 0, 0)">
+          <g>
+            <path stroke-width="500" d="M0 336 H12800" class="underline" stroke="#595959"/>
+          </g>
+        </g>
+      </g>
+    </svg>
+  </g>
+</svg>


### PR DESCRIPTION
Hi! @larrylynn-wf directed me here. I've been debugging some line width fidelity issues in one of our products and have tracked the issue down to applyStroke().

Currently, line widths in canvases with a rotation transform will vary based on the angle of the line. I think this is because applyStroke only takes the transform's X scale into account when calculating line width. This results in rotated lines becoming progressively thinner until they eventually become zero-width lines at 90 / 270 degrees. Here's an [SVG illustrating the problem](https://github.com/rototor/pdfbox-graphics2d/compare/master...jonmccracken-wf:fixRotatedStrokeWidth?expand=1#diff-25b312c1b35846cc950a1f36e8ecb4e83c6930374e3aa53df72d9f95d8bbf588): all of the lines are the same width in the original SVG, but their lineWidth in the exported PDF changes based on the rotation of the canvas.

There's a related issue with dashed lines being drawn in with a rotation transform. This can corrupt the PDF. See [this SVG](https://github.com/rototor/pdfbox-graphics2d/compare/master...jonmccracken-wf:fixRotatedStrokeWidth?expand=1#diff-d867b586eeb7e297406566c4023b743b6b978e264651f2db3b2cc710b49bac6b) for more info.

To fix it, I'm representing the stroke width / dashes as an imaginary horizontal vector with magnitude == BasicStroke.LineWidth. I'm then using the transform to to transform that vector into the current transform space and calculating the length of the result. This new vector length is the effective line width or dash length under the current transform.

I ran through the output of RenderSVGsTest and compared it to current master and wasn't able to find any fidelity differences. I also ran the fix through our fidelity suite and was able to verify that there weren't any differences.

Thank you for all your work on this project!

-- Jon
