### PR TITLE
Shrink document size by ensuring that identical images are not included multiple times  

### DIFF
--- a/graphics2d/src/test/java/de/rototor/pdfbox/graphics2d/MultiPageTest.java
+++ b/graphics2d/src/test/java/de/rototor/pdfbox/graphics2d/MultiPageTest.java
@@ -5,6 +5,7 @@ import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.PDPageContentStream;
 import org.apache.pdfbox.pdmodel.common.PDRectangle;
 import org.apache.pdfbox.pdmodel.graphics.form.PDFormXObject;
+import org.apache.pdfbox.pdmodel.graphics.image.PDImageXObject;
 import org.apache.pdfbox.util.Matrix;
 import org.jfree.chart.ChartFactory;
 import org.jfree.chart.ChartUtilities;
@@ -34,6 +35,8 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.HashMap;
+import javax.imageio.ImageIO;
 
 public class MultiPageTest {
 	@Test
@@ -43,13 +46,18 @@ public class MultiPageTest {
 		parentDir.mkdirs();
 		File targetPDF = new File(parentDir, "multipage.pdf");
 		PDDocument document = new PDDocument();
+        HashMap<Image, PDImageXObject> seenImages = new HashMap();
+        Image pageLogo = ImageIO.read(
+                        MultiPageTest.class.getResourceAsStream("Rose-ProPhoto.jpg"));
 		for (int i = 0; i < 6; i++) {
 			PDPage page = new PDPage(PDRectangle.A4);
 			document.addPage(page);
 
 			PDPageContentStream contentStream = new PDPageContentStream(document, page);
 			PdfBoxGraphics2D pdfBoxGraphics2D = new PdfBoxGraphics2D(document, 800, 400);
+            pdfBoxGraphics2D.setRenderingHint(PdfBoxGraphics2D.RenderingHint.IMAGE_SHARING_MAP, seenImages);
 			drawOnGraphics(pdfBoxGraphics2D, i);
+            pdfBoxGraphics2D.drawImage(pageLogo, 0, 0, 75, 50, null);
 			pdfBoxGraphics2D.dispose();
 
 			PDFormXObject appearanceStream = pdfBoxGraphics2D.getXFormObject();


### PR DESCRIPTION
As an example, the feature is useful for for multi page documents with a common logo image on every page.  
It is implemented in form of a rendering hint. Without the hint the default behavior remains unchanged.
Added code to the test case MultiPageTest.java that demonstrates the feature. The resulting file "multipage.pdf" has a size of 1.04 MB with the rendering hint and a size of 5.23 MB otherwise.
The relevant code fragment looks as follows:
```java
PDDocument document = new PDDocument();
        HashMap<Image,PDImageXObject> seenImages = new HashMap();
        Image pageLogo = ImageIO.read(
                        MultiPageTest.class.getResourceAsStream("Rose-ProPhoto.jpg"));
        for (int i = 0; i < 6; i++) {
            PDPage page = new PDPage(PDRectangle.A4);
            document.addPage(page);

            PDPageContentStream contentStream = new PDPageContentStream(document, page);
            PdfBoxGraphics2D pdfBoxGraphics2D = new PdfBoxGraphics2D(document, 800, 400);
            pdfBoxGraphics2D.setRenderingHint(PdfBoxGraphics2D.RenderingHint.IMAGE_SHARING_MAP, seenImages);
            drawOnGraphics(pdfBoxGraphics2D, i);
            pdfBoxGraphics2D.drawImage(pageLogo, 0, 0, 75, 50, null);
            pdfBoxGraphics2D.dispose();

```
Please note that if the same image in a document is drawn once with the  VALUE_INTERPOLATION_NEAREST_NEIGHBOR and another time without, the rendering hint IMAGE_SHARING_MAP will not recognize them as distinct images so that users need to use two maps or disable sharing for one type of image.