### PR TITLE
Add osgi metadata

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,46 @@
 	</dependencies>
 
 	<build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>org.apache.felix</groupId>
+					<artifactId>maven-bundle-plugin</artifactId>
+					<version>5.1.9</version>
+					<configuration>
+						<supportedProjectTypes>
+							<supportedProjectType>jar</supportedProjectType>
+							<supportedProjectType>bundle</supportedProjectType>
+						</supportedProjectTypes>
+						<instructions>
+							<Import-Package>
+								!java
+							</Import-Package>
+							<Export-Package>
+								{local-packages}
+							</Export-Package>
+						</instructions>
+					</configuration>
+					<executions>
+						<execution>
+							<id>manifest</id>
+							<goals>
+								<goal>manifest</goal>
+							</goals>
+							<configuration>
+								<supportIncrementalBuild>true</supportIncrementalBuild>
+							</configuration>
+						</execution>
+						<execution>
+							<id>bundle</id>
+							<goals>
+								<goal>bundle</goal>
+							</goals>
+						</execution>
+					</executions>
+				</plugin>
+			</plugins>
+		</pluginManagement>
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
@@ -187,7 +227,10 @@
 					</archive>
 				</configuration>
 			</plugin>
-
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+			</plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
Hi there,

I am working on the Lucee project's PDF extension https://github.com/lucee/extension-pdf, upgrading from flying saucer to https://github.com/openhtmltopdf/openhtmltopdf which uses your library with pdfbox.

Both those libraries support OSGI, this PR adds OSGI metadata for your library to complete the dependency chain

Regards

Zac

